### PR TITLE
Gestures priority & ProgressView

### DIFF
--- a/Sources/CompactSlider/CompactSlider.swift
+++ b/Sources/CompactSlider/CompactSlider.swift
@@ -305,7 +305,7 @@ private extension View {
         )
 #else
         delayedGesture(enableDragGestureDelayForiOS)
-            .gesture(
+            .highPriorityGesture(
                 DragGesture(minimumDistance: 1)
                     .onChanged(onChanged)
                     .onEnded(onEnded)

--- a/Sources/CompactSlider/ProgressView.swift
+++ b/Sources/CompactSlider/ProgressView.swift
@@ -5,7 +5,7 @@
 
 import SwiftUI
 
-struct ProgressView: View {
+struct CProgressView: View {
     
     @Environment(\.compactSliderSecondaryAppearance) var secondaryAppearance
     
@@ -26,7 +26,7 @@ struct ProgressView: View {
 extension CompactSlider {
     
     func progressView(in size: CGSize) -> some View {
-        ProgressView(
+        CProgressView(
             width: progressWidth(size),
             offsetX: progressOffsetX(size),
             isFocused: isHovering || isDragging


### PR DESCRIPTION
1.Increase the priority of swipe gestures to avoid being blocked by external gestures.
2.Rename ProgressView to avoid conflicts with the system's ProgressView.